### PR TITLE
Switch to Confluent Kafka suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,26 +14,48 @@ services:
       - 6379:6379
   zookeeper:
     container_name: cqrs-es-zookeeper
-    image: wurstmeister/zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.0
     restart: unless-stopped
     ports:
       - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
     container_name: cqrs-es-kafka
-    image: wurstmeister/kafka:2.11-1.1.1
+    image: confluentinc/cp-kafka:7.2.0
     restart: unless-stopped
     ports:
       - 9092:9092
+    expose:
+      - 29092
     depends_on:
       - zookeeper
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT_HOST://localhost:9092,PLAINTEXT://kafka:29092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CREATE_TOPICS: "application:1:1,job:1:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+  init-kafka:
+    image: confluentinc/cp-kafka:7.2.0
+    depends_on:
+      - kafka
+    entrypoint: ['/bin/sh', '-c']
+    command: |
+      "
+        kafka-topics --bootstrap-server kafka:29092 --list
+        
+        echo -e 'Creating topics ...'
+        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic job --replication-factor 1 --partitions 1
+        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic application --replication-factor 1 --partitions 1
+        
+        echo -e 'Successfully created topics:'
+        kafka-topics --bootstrap-server kafka:29092 --list
+      "
 networks:
   default:
     name: cqrs-es-net


### PR DESCRIPTION
- Change Zookeeper
- Change Kafka
- Init Container added to create topic on start up due to the fact that Confluent image does not support auto topic creation

Note: I do this because I want to leverage Confluent ecosystem in the future e.g. Kafka Connect or KSqlDB